### PR TITLE
Cert singing delegate fix

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,10 @@ icinga2_client_api_pass: ""
 # next host which can reach the config master. unset by default
 # icinga2_client_master_reachable_host: ''
 
+# The signing master where the cert signing will be delegated
+# to if icinga2_client_master_reachable_host is set.
+# icinga2_client_csr_signing_master: ''
+
 # Packages which should be installed additionally for custom check commands
 # Defaults to an empty list
 icinga2_client_custom_check_packages: []

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -52,7 +52,7 @@
   command: cat /var/lib/icinga2/certs/ca.crt
   register: icinga2_client_register_ca
   when: icinga2_client_master_reachable_host is defined and not icinga2_client_register_ca_created.stat.exists
-  delegate_to: '{{ icinga2_client_master_reachable_host }}'
+  delegate_to: '{{ icinga2_client_csr_signing_master }}'
 
 - name: save ca from icinga2 master (delegate)
   copy:
@@ -114,5 +114,5 @@
 - name: sign certificate request on master
   command: >
     icinga2 ca sign {{ icinga2_client_register_certfinger['stdout'] }}
-  delegate_to: '{{ icinga2_client_master_reachable_host }}'
+  delegate_to: '{{ icinga2_client_csr_signing_master }}'
   when: icinga2_client_master_reachable_host is defined and icinga2_client_register_certs_created.changed # noqa 503

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -108,6 +108,8 @@
     openssl x509
     -in /var/lib/icinga2/certs/{{ inventory_hostname }}.crt
     -fingerprint -sha256 -noout | cut -d '=' -f 2 | sed 's/://g' | tr A-Z a-z
+  args:
+    executable: /bin/bash
   register: icinga2_client_register_certfinger
   when: icinga2_client_master_reachable_host is defined and icinga2_client_register_certs_created.changed # noqa 503
 


### PR DESCRIPTION
##### SUMMARY
- Use icinga2_client_csr_signing_master for singing cert signing delegate: `icinga2_client_master_reachable_host` is used to point to the next reachable sat, certs however can't be signed on a satellite but have to be signed on the master.
- Use bash for cert fingerprint reading, `-o pipefail` doesn't work in `dash`

##### ISSUE TYPE
 - Bugfix Pull Request
