### PR TITLE
Consistently use inventory_hostname as cn for the certificate

### DIFF
--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -81,6 +81,7 @@
     --parent_zone {{ icinga2_client_parent_zone }} \
     --ticket {{ icinga2_client_register_ticket.json.results.0.ticket }} \
     --trustedcert /var/lib/icinga2/certs/icinga2_master_ca.crt \
+    --cn {{ inventory_hostname }}
     --accept-config --accept-commands
   args:
     creates: /var/lib/icinga2/certs/ca.crt


### PR DESCRIPTION
##### SUMMARY
Consistently use inventory_hostname as cn for the certificate. This way we don't have to rely on the inventory_hostname matching `hostname -f` anymore.

##### ISSUE TYPE
 - Bugfix Pull Request
