### PR TITLE
feat: add support for nested satellites

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,9 @@ icinga2_client_monitoring_parents:
 # The default icinga2 parent zone
 icinga2_client_parent_zone: monitoring-master
 
+# Zones of child satellites
+icinga2_client_child_satellites: []
+
 # The signing master where the signing ticket creation will be delegated to.
 icinga2_client_csr_signing_master: "{{ icinga2_client_monitoring_parents[0] }}"
 

--- a/templates/etc/icinga2/zones.conf.j2
+++ b/templates/etc/icinga2/zones.conf.j2
@@ -31,3 +31,15 @@ object Zone "{{ inventory_hostname }}" {
   endpoints = [ "{{ inventory_hostname }}" ]
   parent = "{{ icinga2_client_parent_zone }}"
 }
+{# Each child satellite gets and endpoint definition #}
+{% for item in icinga2_client_child_satellites %}
+
+object Endpoint "{{ item }}" {
+  host = "{{ item }}"
+}
+
+object Zone "{{ item }}" {
+  endpoints = [ "{{ item }}" ]
+  parent = "{{ inventory_hostname }}"
+}
+{% endfor %}


### PR DESCRIPTION
##### SUMMARY

Our current Icinga2 deployment only permits one satellite layer between the master nodes and client endpoints.

When creating a satellite (child) in Icinga Director that is in the cluster-zone of another satellite (parent), the endpoint and zone objects for the child satellite are not created in the Director-generated config rendered on the parent satellite.

This PR adds a new variable `icinga2_client_child_satellites` that allows child satellites to be added into the `/etc/icinga2/zones.conf` of its parent.

This change is accompanied by a related change in the `icinga2_client` role: https://github.com/adfinis/ansible-role-icinga2_master/pull/139

##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
```
ansible [core 2.19.4]
  config file = /home/.../ansible.cfg
  configured module search path = ['/home/.../.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /home/.../ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.13.5 (main, May  5 2026, 21:05:52) [GCC 14.2.0] (/usr/bin/python3)
  jinja version = 3.1.6
  pyyaml version = 6.0.2 (with libyaml v0.2.5)
```
