### PR TITLE
fix: add tag to signing task

### DIFF
--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -65,3 +65,5 @@
       - "{{ icinga2_client_register_cert_fingerprint.stdout.split('=')[1] | replace(':', '') | lower }}"
   when: icinga2_client_register_create_client_cert.changed and not ansible_check_mode
   delegate_to: "{{ icinga2_client_csr_signing_master }}"
+  tags:
+    - role::icinga2_client:cert:signging


### PR DESCRIPTION
##### SUMMARY
Adding a tag to the signing task so it can be skipped
